### PR TITLE
Fix module.prop add minMagisk

### DIFF
--- a/module.prop
+++ b/module.prop
@@ -5,3 +5,4 @@ versionCode=12
 author=Ryaniskira
 description=Installs F-Droid Privileged Extension systemlessly
 template=1500
+minMagisk=1500


### PR DESCRIPTION
[update-binary][update-binary] checks minMagisk in module.prop

alternatively, `grep_prop template` in [update-binary]


[update-binary]: https://github.com/john-tho/Fdroid-Priv/blob/5cf614a9ec3bc16d82652ade8acb0dd224c79d63/META-INF/com/google/android/update-binary#L80

Fixes install on Magisk v15 for me